### PR TITLE
DOCS: Update cleanup Command for FrontendLogin

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Clone the repository into your Neos `Packages/Application/` folder and paste the
 ```
 
 Since our package currently conflicts with the default FrontendLogin package, we need to remove it prior visiting the new backend interface.
-Execute the following command in your shell to delete the FrontendLogin package and to install all frontend dependencies as well as build the frontend application bundles.
+Execute the following command in your shell to delete the FrontendLogin and the NeosDemoTypo3Org package and to install all frontend dependencies as well as build the frontend application bundles.
 ```
-composer remove flowpack/neos-frontendlogin && rm -rf Data/Temporary/* && cd Packages/Application/PackageFactory.Guevara && bash Build/init.sh
+composer remove flowpack/neos-frontendlogin typo3/neosdemotypo3org && rm -rf Data/Temporary/* && rm Configuration/PackageStates.php && rm -rf Packages/Plugins/Flowpack.Neos.FrontendLogin/ && cd Packages/Application/PackageFactory.Guevara && bash Build/init.sh
 ```
 
 After the script has finished, you are all set up and can open the sub-route `/che!` to login to the new interface.


### PR DESCRIPTION
Make sure the NeosDemoTypo3Org and its dependency FrontendLogin are removed including all leftovers.

+ remove PackageStates.php
+ remove NeosDemoTypo3Org package or "composer remove flowpack/neos-frontendlogin" will fail if NeosDemoTypo3Org is installed.