### PR TITLE
Apply Workaround to achieve compatibility with Flowpack.Neos.FrontendLogin

### DIFF
--- a/Classes/PackageFactory/Guevara/Aspects/FlowpackFrontendLoginCompatibilityAspect.php
+++ b/Classes/PackageFactory/Guevara/Aspects/FlowpackFrontendLoginCompatibilityAspect.php
@@ -1,0 +1,51 @@
+<?php
+namespace PackageFactory\Guevara\Aspects;
+
+/*                                                                        *
+ * This script belongs to the TYPO3 Flow package "PackageFactory.Guevara".*
+ *                                                                        *
+ *                                                                        */
+
+use TYPO3\Flow\Annotations as Flow;
+use TYPO3\FLOW\AOP\JoinPointInterface;
+use Flowpack\Neos\FrontendLogin\Security\NeosRequestPattern;
+
+/**
+ * @TODO !!! Remove this, when there's a better way to achieve compatibility
+ *
+ * This Aspect helps us to get around compatibility issues with the Flowpack.Neos.FrontendLogin package. The background
+ * is a RequestPattern that is applied via that package.
+ *
+ * This request pattern tries to distinguish between frontend and backend routes, but only matches backend routes that
+ * start with '/neos'.
+ *
+ * With this aspect the behavior is enhanced to consider routes starting with '/che!' as well.
+ *
+ * It is important to find a better way to support Flowpack.Neos.FrontendLogin, since PackageFactory.Guevara should not
+ * have a dependency to it. Therefore this aspect avoids a direct dependency, it is still implicit though.
+ *
+ * @Flow\Scope("singleton")
+ * @Flow\Aspect
+ */
+class FlowpackFrontendLoginCompatibilityAspect
+{
+
+    /**
+     * @Flow\Around("method(Flowpack\Neos\FrontendLogin\Security\NeosRequestPattern->matchRequest())")
+     * @param JoinPointInterface $joinPoint
+     * @return boolean
+     */
+    public function enhanceMatchRequest(JoinPointInterface $joinPoint)
+    {
+        $request = $joinPoint->getMethodArgument('request');
+        $requestPath = $request->getHttpRequest()->getUri()->getPath();
+
+        if ($joinPoint->getProxy()->getPattern() === NeosRequestPattern::PATTERN_BACKEND) {
+            if (strpos($requestPath, '/che!') === 0) {
+                return true;
+            }
+        }
+
+        return $joinPoint->getAdviceChain()->proceed($joinPoint);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -20,14 +20,7 @@
 ## Installation
 *Full composer support coming soon...*
 
-1. Since our package currently conflicts with the default FrontendLogin package, we need to
-   remove it.  
-   **Remove the following line** from your `composer.json` file:  
-   ```
-   "flowpack/neos-frontendlogin": "@dev"
-   ```
-
-2. Add the following lines to your `composer.json` (our package is not published to composer
+1. Add the following lines to your `composer.json` (our package is not published to composer
    repository yet, so we need to give composer hints where to find it):
    ```
     "repositories": [
@@ -36,17 +29,15 @@
    ```
    Note: if you plan to contribute to the project, fork it and provide VCS url to your forked repository.
 
-3. Run the following commands:  
+2. Run the following commands:  
    ```
-   rm -rf Packages/Plugins/Flowpack.Neos.FrontendLogin # remove the conflicting FrontendLogin
-   rm -rf Data/Temporary/* Configuration/PackageStates.php # clear the caches
    composer require packagefactory/guevara:dev-master # install our package
    cd Packages/Application/PackageFactory.Guevara
    source Build/init.sh # do NodeJS stuff ie. install required node version using nvm, install npm deps
    npm run build # build everything using webpack (you might see some webpack warnings, but you can ignore them)
    ```
 
-4. Paste the following configuration into the **head** of your global `Routes.yaml` which is located in `Configuration/`  
+3. Paste the following configuration into the **head** of your global `Routes.yaml` which is located in `Configuration/`  
    ```yaml
 -
   name: 'PackageFactory Guevara'


### PR DESCRIPTION
This PR introduces an Aspect to (temporarily) get rid of the issues with Flowpack.Neos.FrontendLogin.

The background is a RequestPattern that is applied via the FrontendLogin package.

This request pattern tries to distinguish between frontend and backend routes, but only matches backend routes that start with '/neos'.

With this aspect the behavior is enhanced to consider routes starting with '/che!' as well.

It is important to find a better way to support Flowpack.Neos.FrontendLogin, since PackageFactory.Guevara should not have a dependency to it. Therefore this aspect avoids a direct dependency, it is still implicit though.

Imho this issue even needs to be solved in Flowpack.Neos.FrontendLogin itself, since it makes the assumption, that the neos backend will always be available via `/neos/...`, which is not necessarily the case.

For Guevara this might not remain an issue, because it will most likely not keep its `/che!` route.