### PR TITLE
Feature: Neos Decorator

### DIFF
--- a/Resources/Private/JavaScript/Host/Containers/LeftSideBar/index.js
+++ b/Resources/Private/JavaScript/Host/Containers/LeftSideBar/index.js
@@ -4,6 +4,7 @@ import {connect} from 'react-redux';
 import {$transform, $get, $or} from 'plow-js';
 
 import {SideBar} from 'Components/index';
+import neos from 'Host/Decorators/Neos/index';
 
 import NodeTreeToolBar from './NodeTreeToolBar/index';
 import PageTree from './PageTree/index';
@@ -15,8 +16,10 @@ import style from './style.css';
         $get('ui.fullScreen.isFullScreen')
     )
 }))
+@neos()
 export default class LeftSideBar extends Component {
     static propTypes = {
+        neos: PropTypes.object.isRequired,
         isHidden: PropTypes.bool.isRequired
     };
 
@@ -26,6 +29,8 @@ export default class LeftSideBar extends Component {
             [style.leftSideBar]: true,
             [style['leftSideBar--isHidden']]: isHidden
         });
+
+        console.log(this.props.neos);
 
         return (
             <SideBar

--- a/Resources/Private/JavaScript/Host/Containers/LeftSideBar/index.js
+++ b/Resources/Private/JavaScript/Host/Containers/LeftSideBar/index.js
@@ -4,7 +4,6 @@ import {connect} from 'react-redux';
 import {$transform, $get, $or} from 'plow-js';
 
 import {SideBar} from 'Components/index';
-import neos from 'Host/Decorators/Neos/index';
 
 import NodeTreeToolBar from './NodeTreeToolBar/index';
 import PageTree from './PageTree/index';
@@ -16,10 +15,8 @@ import style from './style.css';
         $get('ui.fullScreen.isFullScreen')
     )
 }))
-@neos()
 export default class LeftSideBar extends Component {
     static propTypes = {
-        neos: PropTypes.object.isRequired,
         isHidden: PropTypes.bool.isRequired
     };
 
@@ -29,8 +26,6 @@ export default class LeftSideBar extends Component {
             [style.leftSideBar]: true,
             [style['leftSideBar--isHidden']]: isHidden
         });
-
-        console.log(this.props.neos);
 
         return (
             <SideBar

--- a/Resources/Private/JavaScript/Host/Containers/Neos/index.js
+++ b/Resources/Private/JavaScript/Host/Containers/Neos/index.js
@@ -1,4 +1,4 @@
-import React, {Component, PropTypes, Children} from 'react';
+import {Component, PropTypes, Children} from 'react';
 
 export default class Neos extends Component {
     static propTypes = {

--- a/Resources/Private/JavaScript/Host/Containers/Neos/index.js
+++ b/Resources/Private/JavaScript/Host/Containers/Neos/index.js
@@ -1,0 +1,21 @@
+import React, {Component, PropTypes, Children} from 'react';
+
+export default class Neos extends Component {
+    static propTypes = {
+        configuration: PropTypes.object.isRequired,
+        children: PropTypes.element.isRequired
+    };
+
+    static childContextTypes = {
+        configuration: PropTypes.object.isRequired
+    };
+
+    getChildContext() {
+        const {configuration} = this.props;
+        return {configuration};
+    }
+
+    render() {
+        return Children.only(this.props.children);
+    }
+}

--- a/Resources/Private/JavaScript/Host/Containers/index.js
+++ b/Resources/Private/JavaScript/Host/Containers/index.js
@@ -1,3 +1,4 @@
+import Neos from './Neos/index';
 import ContentView from './ContentView/index';
 import ContextBar from './ContextBar/index';
 import FlashMessageContainer from './FlashMessageContainer/index';
@@ -9,6 +10,7 @@ import RightSideBar from './RightSideBar/index';
 import AddNodeModal from './AddNodeModal/index';
 
 export {
+    Neos,
     ContentView,
     ContextBar,
     FlashMessageContainer,

--- a/Resources/Private/JavaScript/Host/Decorators/Neos/index.js
+++ b/Resources/Private/JavaScript/Host/Decorators/Neos/index.js
@@ -1,7 +1,10 @@
 import React, {Component, PropTypes} from 'react';
 
+//
+// A higher order component to easily spread global
+// configuration
+//
 export default () => WrappedComponent => {
-
     return class NeosDecorator extends Component {
         static contextTypes = {
             configuration: PropTypes.object.isRequired
@@ -19,5 +22,5 @@ export default () => WrappedComponent => {
                     />
             );
         }
-    }
+    };
 };

--- a/Resources/Private/JavaScript/Host/Decorators/Neos/index.js
+++ b/Resources/Private/JavaScript/Host/Decorators/Neos/index.js
@@ -1,0 +1,23 @@
+import React, {Component, PropTypes} from 'react';
+
+export default () => WrappedComponent => {
+
+    return class NeosDecorator extends Component {
+        static contextTypes = {
+            configuration: PropTypes.object.isRequired
+        };
+
+        static displayName = `Neos(${WrappedComponent.displayName || WrappedComponent.name || 'Component'})`;
+
+        render() {
+            const {configuration} = this.context;
+
+            return (
+                <WrappedComponent
+                    neos={{configuration}}
+                    {...this.props}
+                    />
+            );
+        }
+    }
+};

--- a/Resources/Private/JavaScript/Host/index.js
+++ b/Resources/Private/JavaScript/Host/index.js
@@ -39,6 +39,7 @@ import style from './style.css';
 document.addEventListener('DOMContentLoaded', () => {
     const appContainer = document.getElementById('appContainer');
     const csrfToken = appContainer.dataset.csrfToken;
+    const configuration = JSON.parse(appContainer.querySelector('[data-json="configuration"]').innerHTML);
     const serverState = JSON.parse(appContainer.querySelector('[data-json="initialState"]').innerHTML);
     const translations = JSON.parse(appContainer.querySelector('[data-json="translations"]').innerHTML);
     const neos = initializeJSAPI(window, csrfToken);
@@ -55,7 +56,7 @@ document.addEventListener('DOMContentLoaded', () => {
     ReactDOM.render(
         <div className={style.applicationWrapper}>
             <Provider store={store}>
-                <Neos configuration={{test: 'works'}}>
+                <Neos configuration={configuration}>
                     <div>
                         <div id="dialog" />
                         <FlashMessageContainer />

--- a/Resources/Private/JavaScript/Host/index.js
+++ b/Resources/Private/JavaScript/Host/index.js
@@ -15,6 +15,7 @@ import {ui} from './Plugins/index';
 import * as feedbackHandler from './Service/FeedbackHandler/index';
 
 import {
+    Neos,
     ContentView,
     TopBar,
     LeftSideBar,
@@ -54,18 +55,20 @@ document.addEventListener('DOMContentLoaded', () => {
     ReactDOM.render(
         <div className={style.applicationWrapper}>
             <Provider store={store}>
-                <div>
-                    <div id="dialog" />
-                    <FlashMessageContainer />
-                    <FullScreen />
-                    <TopBar />
-                    <ContextBar />
-                    <OffCanvas />
-                    <AddNodeModal />
-                    <LeftSideBar />
-                    <ContentView />
-                    <RightSideBar />
-              </div>
+                <Neos configuration={{test: 'works'}}>
+                    <div>
+                        <div id="dialog" />
+                        <FlashMessageContainer />
+                        <FullScreen />
+                        <TopBar />
+                        <ContextBar />
+                        <OffCanvas />
+                        <AddNodeModal />
+                        <LeftSideBar />
+                        <ContentView />
+                        <RightSideBar />
+                    </div>
+                </Neos>
             </Provider>
         </div>,
         appContainer

--- a/Resources/Private/Templates/Backend/Index.html
+++ b/Resources/Private/Templates/Backend/Index.html
@@ -8,6 +8,7 @@
     </head>
     <body>
         <div id="appContainer" data-csrf-token="{f:security.csrfToken()}" data-first-tab="{documentNodeUri}">
+            <div data-json="configuration">{configuration}</div>
             <div data-json="initialState">{initialState}</div>
             <div data-json="translations">{translations}</div>
         </div>

--- a/Resources/Private/TypoScript/Backend/Root.ts2
+++ b/Resources/Private/TypoScript/Backend/Root.ts2
@@ -3,6 +3,10 @@ include: resource://PackageFactory.Guevara/Private/TypoScript/Prototypes/RenderS
 backend = TYPO3.TypoScript:Template {
     templatePath = 'resource://PackageFactory.Guevara/Private/Templates/Backend/Index.html'
 
+    configuration = TYPO3.TypoScript:RawArray {
+        @process.json = ${Json.stringify(value)}
+    }
+
     initialState = PackageFactory.Guevara:RenderState {
         state = 'backend'
         context {


### PR DESCRIPTION
This PR introduces a higher order Component, that can be used as a decorator for various Containers. The idea is to spread global configuration, that is obtained during initialization.

It will also enable us to pass a central api around, instead of accessing action creators directly. This will help to keep Host/Guest functionality in sync.

Here's a usage example:

```
@neos()
class MyComponent extends Component {
    static propTypes = {
        neos: PropTypes.object.isRequired
    };
    
    render() {
        const {configuration} = this.props.neos;
        return (<div>{configuration.someConfiguredValue}</div>);
    }
}
```

A configuration object is currently passed via TypoScript in `Resources/Private/TypoScript/Backend/Root.ts2`.